### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/obestwalter/loslassa.png?label=ready&title=Ready 
+ :target: https://waffle.io/obestwalter/loslassa
+ :alt: 'Stories in Ready'
 |TravisBadge|_  |CoverallBadge|_  |PyPiBadge|_ |CommitMood|_
 
 .. |TravisBadge| image:: https://travis-ci.org/obestwalter/loslassa.png?branch=master


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/obestwalter/loslassa

This was requested by a real person (user obestwalter) on waffle.io, we're not trying to spam you.
